### PR TITLE
Add elevation cost breakdown and discount clarity

### DIFF
--- a/web/src/app/project/[name]/page.tsx
+++ b/web/src/app/project/[name]/page.tsx
@@ -337,6 +337,44 @@ export default function ProjectPage({ params }: ProjectPageProps) {
       discountedTotal += DISCOUNTABLE.has(cat) ? price * multiplier : price;
     }
 
+    // Include field costs (installation labor, perimeter sealants, break metal)
+    const w = elev.opening_width_inches || 0;
+    const h = elev.opening_height_inches || 0;
+    const perimFt = (2 * (w + h)) / 12;
+    const laborRate = settings.installation_labor_rate ?? 65;
+    const laborMkp = 1 + (settings.installation_labor_markup_pct ?? 0) / 100;
+    const sealRate = settings.sealant_rate_per_ft ?? 3.5;
+    const sealMkp = 1 + (settings.sealant_markup_pct ?? 0) / 100;
+    const bmRate = settings.break_metal_rate_per_ft ?? 12;
+    const bmMkp = 1 + (settings.break_metal_markup_pct ?? 0) / 100;
+
+    if (elev.installation_labor_hours && elev.installation_labor_hours > 0) {
+      const cost = elev.installation_labor_hours * laborRate * laborMkp;
+      listTotal += cost;
+      discountedTotal += cost;
+    }
+    if (elev.sealant_joints && elev.sealant_joints > 0) {
+      const cost = elev.sealant_joints * sealRate * perimFt * sealMkp;
+      listTotal += cost;
+      discountedTotal += cost;
+    }
+    if (elev.break_metal_selections && elev.break_metal_selections.length > 0) {
+      const wFt = w / 12;
+      const hFt = h / 12;
+      let linFt = 0;
+      for (const sel of elev.break_metal_selections) {
+        if (sel === 'Perimeter') linFt += 2 * (wFt + hFt);
+        else if (sel === 'Head') linFt += wFt;
+        else if (sel === 'Sill') linFt += wFt;
+        else if (sel === 'Left Jamb') linFt += hFt;
+        else if (sel === 'Right Jamb') linFt += hFt;
+        else if (sel === 'Both Jambs') linFt += 2 * hFt;
+      }
+      const cost = linFt * bmRate * bmMkp;
+      listTotal += cost;
+      discountedTotal += cost;
+    }
+
     return { list: listTotal, discounted: discountedTotal };
   }
 

--- a/web/src/components/CostSummary.tsx
+++ b/web/src/components/CostSummary.tsx
@@ -460,6 +460,9 @@ export default function CostSummary({ elevations, materials, settings }: CostSum
           </span>
           <span className="text-[#3b82f6] font-mono font-semibold tabular-nums">
             x {multiplier.toFixed(3)}
+            <span className="text-xs text-[#ffffff]/50 ml-1">
+              ({((1 - multiplier) * 100).toFixed(1)}% off)
+            </span>
           </span>
         </div>
 

--- a/web/src/components/ElevationEditor.tsx
+++ b/web/src/components/ElevationEditor.tsx
@@ -1333,57 +1333,6 @@ export default function ElevationEditor({
                 </div>
               )}
 
-              {/* D.L.O. & Glass Make Size summary */}
-              {openingWidth > 0 && openingHeight > 0 && (() => {
-                const resolvedWidths = baysWide > 1 ? customBayWidths : [openingWidth];
-                const resolvedHeights = baysTall > 1 ? customBayHeights : [openingHeight];
-                const { dloWidths, dloHeights } = buildDloGrid(resolvedWidths, resolvedHeights);
-                return (
-                  <div className="mt-3 rounded-lg border border-[#1e1e2a] bg-[#0a0a10] p-3 space-y-2">
-                    <p className="text-[10px] font-semibold text-[#ffffff] uppercase tracking-wider">
-                      D.L.O. &amp; Glass Make Size
-                    </p>
-                    <div className="text-[10px] text-[#ffffff]/60 space-x-3">
-                      <span>Edge &minus;{DLO_EDGE_DEDUCTION}&Prime;</span>
-                      <span>Interior &minus;{DLO_INTERIOR_DEDUCTION}&Prime;</span>
-                      <span>Sill &minus;{DLO_SILL_DEDUCTION.toFixed(4).replace(/0+$/, '').replace(/\.$/, '')}&Prime;</span>
-                      <span>Glass = DLO + &frac34;&Prime;</span>
-                    </div>
-                    {/* Width D.L.O. */}
-                    <div>
-                      <p className="text-[10px] text-[#ffffff]/70 font-medium mb-1">Widths</p>
-                      <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3 md:grid-cols-4">
-                        {resolvedWidths.map((w, col) => (
-                          <div key={col} className="text-xs font-mono">
-                            <span className="text-[#ffffff]/50">B{col + 1}: </span>
-                            <span className="text-[#ffffff]">{w.toFixed(2)}&Prime;</span>
-                            <span className="text-[#ffffff]/40 mx-0.5">&rarr;</span>
-                            <span className="text-blue-400">{dloWidths[col].toFixed(2)}&Prime;</span>
-                            <span className="text-[#ffffff]/40 mx-0.5">&rarr;</span>
-                            <span className="text-emerald-400">{calculateGlassMakeSize(dloWidths[col]).toFixed(2)}&Prime;</span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                    {/* Height D.L.O. */}
-                    <div>
-                      <p className="text-[10px] text-[#ffffff]/70 font-medium mb-1">Heights (bottom &rarr; top)</p>
-                      <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3 md:grid-cols-4">
-                        {resolvedHeights.map((h, row) => (
-                          <div key={row} className="text-xs font-mono">
-                            <span className="text-[#ffffff]/50">R{row + 1}{row === 0 ? ' (Bot)' : ''}: </span>
-                            <span className="text-[#ffffff]">{h.toFixed(2)}&Prime;</span>
-                            <span className="text-[#ffffff]/40 mx-0.5">&rarr;</span>
-                            <span className="text-blue-400">{dloHeights[0][row].toFixed(2)}&Prime;</span>
-                            <span className="text-[#ffffff]/40 mx-0.5">&rarr;</span>
-                            <span className="text-emerald-400">{calculateGlassMakeSize(dloHeights[0][row]).toFixed(2)}&Prime;</span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })()}
             </>
           )}
         </div>
@@ -1607,9 +1556,17 @@ export default function ElevationEditor({
                         key={opt}
                         type="button"
                         onClick={() => {
-                          setBreakMetalSelections((prev) =>
-                            selected ? prev.filter((s) => s !== opt) : [...prev, opt],
-                          );
+                          setBreakMetalSelections((prev) => {
+                            if (selected) return prev.filter((s) => s !== opt);
+                            if (opt === 'Perimeter') return ['Perimeter'];
+                            let next = prev.filter((s) => s !== 'Perimeter');
+                            if (opt === 'Both Jambs') {
+                              next = next.filter((s) => s !== 'Left Jamb' && s !== 'Right Jamb');
+                            } else if (opt === 'Left Jamb' || opt === 'Right Jamb') {
+                              next = next.filter((s) => s !== 'Both Jambs');
+                            }
+                            return [...next, opt];
+                          });
                         }}
                         className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors duration-150 ${
                           selected
@@ -1725,9 +1682,23 @@ export default function ElevationEditor({
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-5">
                 <div>
-                  <p className="text-[10px] text-[#ffffff] font-semibold uppercase tracking-wider mb-1">List Price Total</p>
+                  <p className="text-[10px] text-[#ffffff] font-semibold uppercase tracking-wider mb-1">List Price</p>
                   <p className="text-xl font-bold font-mono text-white tabular-nums">
                     {formatCurrency(grandTotal)}
+                  </p>
+                </div>
+                <div className="w-px h-12 bg-[#1e1e2a]" />
+                <div>
+                  <p className="text-[10px] text-[#ffffff] font-semibold uppercase tracking-wider mb-1">Elevation Total</p>
+                  <p className="text-xl font-bold font-mono text-emerald-400 tabular-nums">
+                    {formatCurrency(
+                      groupedResults.reduce((s, g) => {
+                        const sectionTotal = g.items.reduce((a, r) => a + (r.price ?? 0), 0);
+                        return s + (g.isDiscountable ? sectionTotal * discountMultiplier : sectionTotal);
+                      }, 0)
+                      + ((installationLaborHours || 0) * (settings.installation_labor_rate ?? 65) * (1 + (settings.installation_labor_markup_pct ?? 0) / 100))
+                      + ((sealantJoints || 0) * (settings.sealant_rate_per_ft ?? 3.5) * ((2 * (openingWidth + openingHeight)) / 12) * (1 + (settings.sealant_markup_pct ?? 0) / 100))
+                    )}
                   </p>
                 </div>
                 <div className="w-px h-12 bg-[#1e1e2a]" />
@@ -1763,6 +1734,55 @@ export default function ElevationEditor({
                 )}
               </button>
             </div>
+
+            {/* Per-category cost breakdown (matches Excel COST/ELEVATION) */}
+            {groupedResults.length > 0 && (() => {
+              const laborRate = settings.installation_labor_rate ?? 65;
+              const laborMkp = 1 + (settings.installation_labor_markup_pct ?? 0) / 100;
+              const sealRate = settings.sealant_rate_per_ft ?? 3.5;
+              const sealMkp = 1 + (settings.sealant_markup_pct ?? 0) / 100;
+              const perimFt = (2 * (openingWidth + openingHeight)) / 12;
+              const installCost = (installationLaborHours || 0) * laborRate * laborMkp;
+              const sealCost = (sealantJoints || 0) * sealRate * perimFt * sealMkp;
+
+              const categories = groupedResults.map((g) => {
+                const listTotal = g.items.reduce((a, r) => a + (r.price ?? 0), 0);
+                const discTotal = g.isDiscountable ? listTotal * discountMultiplier : listTotal;
+                return { label: g.label, listTotal, discTotal };
+              });
+
+              const elevTotal = categories.reduce((a, c) => a + c.discTotal, 0) + installCost + sealCost;
+
+              return (
+                <div className="mt-4 pt-3 border-t border-[#1e1e2a]">
+                  <p className="text-[10px] text-[#ffffff]/60 font-semibold uppercase tracking-wider mb-2">Cost / Elevation</p>
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-1">
+                    {categories.map((c) => (
+                      <div key={c.label} className="flex items-center justify-between text-xs">
+                        <span className="text-[#ffffff]/70">{c.label}</span>
+                        <span className="font-mono tabular-nums text-[#ffffff]">{formatCurrency(c.discTotal)}</span>
+                      </div>
+                    ))}
+                    {installCost > 0 && (
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-[#ffffff]/70">Installation Labor</span>
+                        <span className="font-mono tabular-nums text-[#ffffff]">{formatCurrency(installCost)}</span>
+                      </div>
+                    )}
+                    {sealCost > 0 && (
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-[#ffffff]/70">Perimeter Sealants</span>
+                        <span className="font-mono tabular-nums text-[#ffffff]">{formatCurrency(sealCost)}</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex items-center justify-between mt-2 pt-2 border-t border-[#1e1e2a]">
+                    <span className="text-xs font-semibold text-white">Elev Total</span>
+                    <span className="text-sm font-bold font-mono tabular-nums text-emerald-400">{formatCurrency(elevTotal)}</span>
+                  </div>
+                </div>
+              );
+            })()}
           </div>
         )}
 

--- a/web/src/components/PricingAdjustmentTab.tsx
+++ b/web/src/components/PricingAdjustmentTab.tsx
@@ -379,7 +379,10 @@ export default function PricingAdjustmentTab({
                     onChange={(e) => setDiscountMultiplierLow(parseFloat(e.target.value) || 0)}
                     placeholder={String(PRICING_DEFAULTS.discount_multiplier_low)}
                   />
-                  <p className="text-xs text-[#ffffff] mt-1">Default: {PRICING_DEFAULTS.discount_multiplier_low}</p>
+                  <p className="text-xs text-[#ffffff] mt-1">Default: {PRICING_DEFAULTS.discount_multiplier_low} ({((1 - PRICING_DEFAULTS.discount_multiplier_low) * 100).toFixed(1)}% discount)</p>
+                  {discountMultiplierLow > 0 && discountMultiplierLow !== PRICING_DEFAULTS.discount_multiplier_low && (
+                    <p className="text-xs text-blue-400 mt-0.5">= {((1 - discountMultiplierLow) * 100).toFixed(1)}% discount</p>
+                  )}
                 </div>
                 <div>
                   <label className={labelClass}>
@@ -395,7 +398,10 @@ export default function PricingAdjustmentTab({
                     onChange={(e) => setDiscountMultiplierHigh(parseFloat(e.target.value) || 0)}
                     placeholder={String(PRICING_DEFAULTS.discount_multiplier_high)}
                   />
-                  <p className="text-xs text-[#ffffff] mt-1">Default: {PRICING_DEFAULTS.discount_multiplier_high}</p>
+                  <p className="text-xs text-[#ffffff] mt-1">Default: {PRICING_DEFAULTS.discount_multiplier_high} ({((1 - PRICING_DEFAULTS.discount_multiplier_high) * 100).toFixed(1)}% discount)</p>
+                  {discountMultiplierHigh > 0 && discountMultiplierHigh !== PRICING_DEFAULTS.discount_multiplier_high && (
+                    <p className="text-xs text-blue-400 mt-0.5">= {((1 - discountMultiplierHigh) * 100).toFixed(1)}% discount</p>
+                  )}
                 </div>
                 <div>
                   <label className={labelClass}>Discount Threshold ($)</label>

--- a/web/src/lib/export.ts
+++ b/web/src/lib/export.ts
@@ -411,6 +411,17 @@ function writeSystemInput(
       : 'None'],
   ];
 
+  // Field cost inputs (only show when configured)
+  if (elev.installation_labor_hours && elev.installation_labor_hours > 0) {
+    rows.push(['Installation Labor Hours', `${elev.installation_labor_hours} hrs`]);
+  }
+  if (elev.sealant_joints && elev.sealant_joints > 0) {
+    rows.push(['Perimeter Sealant Joints', String(elev.sealant_joints)]);
+  }
+  if (elev.break_metal_selections && elev.break_metal_selections.length > 0) {
+    rows.push(['Break Metal', elev.break_metal_selections.join(', ')]);
+  }
+
   let row = startRow;
   for (const [label, value] of rows) {
     const r = sheet.getRow(row);
@@ -527,6 +538,8 @@ function writeElevationCostSummary(
   startRow: number,
   startCol: number,
   includedSections?: Record<string, boolean>,
+  elev?: ElevationData,
+  settings?: ProjectSettings,
 ): number {
   let row = startRow;
 
@@ -573,6 +586,71 @@ function writeElevationCostSummary(
     row++;
   }
 
+  // Per-elevation field costs
+  if (elev && settings) {
+    const qty = totalCount || 1;
+    const w = elev.opening_width_inches || 0;
+    const h = elev.opening_height_inches || 0;
+    const perimFt = (2 * (w + h)) / 12;
+    const wFt = w / 12;
+    const hFt = h / 12;
+
+    if (elev.installation_labor_hours && elev.installation_labor_hours > 0) {
+      const rate = settings.installation_labor_rate ?? 65;
+      const mkp = 1 + (settings.installation_labor_markup_pct ?? 0) / 100;
+      const perElevCost = elev.installation_labor_hours * rate * mkp;
+      const totalCost = perElevCost * qty;
+      const r = sheet.getRow(row);
+      r.getCell(startCol).value = 'INSTALLATION LABOR';
+      r.getCell(startCol + 1).value = perElevCost;
+      setCurrency(r.getCell(startCol + 1));
+      r.getCell(startCol + 2).value = totalCost;
+      setCurrency(r.getCell(startCol + 2));
+      totalCostPerElev += perElevCost;
+      totalCostAll += totalCost;
+      row++;
+    }
+    if (elev.sealant_joints && elev.sealant_joints > 0) {
+      const rate = settings.sealant_rate_per_ft ?? 3.5;
+      const mkp = 1 + (settings.sealant_markup_pct ?? 0) / 100;
+      const perElevCost = elev.sealant_joints * rate * perimFt * mkp;
+      const totalCost = perElevCost * qty;
+      const r = sheet.getRow(row);
+      r.getCell(startCol).value = 'PERIMETER SEALANTS';
+      r.getCell(startCol + 1).value = perElevCost;
+      setCurrency(r.getCell(startCol + 1));
+      r.getCell(startCol + 2).value = totalCost;
+      setCurrency(r.getCell(startCol + 2));
+      totalCostPerElev += perElevCost;
+      totalCostAll += totalCost;
+      row++;
+    }
+    if (elev.break_metal_selections && elev.break_metal_selections.length > 0) {
+      const rate = settings.break_metal_rate_per_ft ?? 12;
+      const mkp = 1 + (settings.break_metal_markup_pct ?? 0) / 100;
+      let linFt = 0;
+      for (const sel of elev.break_metal_selections) {
+        if (sel === 'Perimeter') linFt += 2 * (wFt + hFt);
+        else if (sel === 'Head') linFt += wFt;
+        else if (sel === 'Sill') linFt += wFt;
+        else if (sel === 'Left Jamb') linFt += hFt;
+        else if (sel === 'Right Jamb') linFt += hFt;
+        else if (sel === 'Both Jambs') linFt += 2 * hFt;
+      }
+      const perElevCost = linFt * rate * mkp;
+      const totalCost = perElevCost * qty;
+      const r = sheet.getRow(row);
+      r.getCell(startCol).value = 'ALUMINUM BREAK METAL';
+      r.getCell(startCol + 1).value = perElevCost;
+      setCurrency(r.getCell(startCol + 1));
+      r.getCell(startCol + 2).value = totalCost;
+      setCurrency(r.getCell(startCol + 2));
+      totalCostPerElev += perElevCost;
+      totalCostAll += totalCost;
+      row++;
+    }
+  }
+
   // Separator
   const sepRow = sheet.getRow(row);
   [startCol, startCol + 1, startCol + 2].forEach(c => {
@@ -593,7 +671,7 @@ function writeElevationCostSummary(
 
   // Note
   const noteRow = sheet.getRow(row);
-  noteRow.getCell(startCol).value = '*Note - Elevation costs based on discounted material costs';
+  noteRow.getCell(startCol).value = '*Note - Elevation costs include discounted materials and field costs';
   setFont(noteRow.getCell(startCol), { size: 9, italic: true, color: '808080' });
   row += 2;
 
@@ -1966,7 +2044,7 @@ export async function exportToExcel(
 
     // --- Elevation Cost Summary ---
     if (elevSections?.elevation_cost_summary !== false) {
-      sectionRow = writeElevationCostSummary(sheet, categories, elevName, totalCount, sectionRow, startCol, elevSections);
+      sectionRow = writeElevationCostSummary(sheet, categories, elevName, totalCount, sectionRow, startCol, elevSections, elev, settings);
     }
 
     // Auto-fit all material columns so descriptions are never truncated


### PR DESCRIPTION
## Summary
- Removed D.L.O. & Glass Make Size section from web UI (still in Excel/PDF exports)
- Added per-category Cost/Elevation breakdown on elevation page (Profiles, Accessories, Gaskets, Glass, Fabrication, Installation Labor, Perimeter Sealants)
- Show both List Price (undiscounted) and Elevation Total (discounted) in summary header
- Display actual discount % next to multiplier values (e.g. `x 0.614 (38.6% off)`)
- Sidebar price now includes field costs (installation labor, perimeter sealants, break metal)
- Excel export includes field costs in per-elevation cost summary

## Test plan
- [ ] Verify D.L.O. section no longer appears on web elevation page
- [ ] Verify Cost/Elevation breakdown shows correct per-category amounts
- [ ] Verify sidebar price matches Elev Total (includes field costs)
- [ ] Verify discount % displays correctly in Pricing tab and Cost Summary
- [ ] Verify Excel export still includes all field costs and matches web totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)